### PR TITLE
Remove unnecessary check on newly submitted transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 - Add `getTransactionByHash` method to `Web3jAbstractService`. (#123)
 - Move `getGasLimitPerFunction` to `PoCoDataEncoder`. (#129)
 
+### Bug Fixes
+
+- Remove unnecessary check on newly submitted transaction. (#132)
+
 ### Quality
 
 - Upgrade source and target compatibility to Java 17. (#114)

--- a/src/main/java/com/iexec/commons/poco/chain/SignerService.java
+++ b/src/main/java/com/iexec/commons/poco/chain/SignerService.java
@@ -200,13 +200,7 @@ public class SignerService {
             throw new JsonRpcError(responseError);
         }
         final String txHash = transactionResponse.getTransactionHash();
-        log.info("Transaction submitted [txHash:{}]", txHash);
-        for (int i = 0; i < 5; i++) {
-            if (verifyTransaction(txHash)) {
-                return txHash;
-            }
-        }
-        log.warn("Could not verify transaction by hash [txHash:{}]", txHash);
+        log.info("Transaction submitted [nonce:{}, txHash:{}]", nonce, txHash);
         return txHash;
     }
 
@@ -221,7 +215,7 @@ public class SignerService {
      * @param txHash hash of the transaction
      * @return {@literal true} if the transaction was found, {@literal false} otherwise
      */
-    boolean verifyTransaction(final String txHash) {
+    public boolean verifyTransaction(final String txHash) {
         if (!BytesUtils.isNonZeroedBytes32(txHash)) {
             log.warn("Invalid transaction hash [txHash:{}]", txHash);
             return false;


### PR DESCRIPTION
The log is never triggered and the transaction can still be dropped.